### PR TITLE
Add an optional Aggregate method to GroupBy

### DIFF
--- a/ReactiveETL/Helpers/OperationsExtensions.cs
+++ b/ReactiveETL/Helpers/OperationsExtensions.cs
@@ -201,6 +201,13 @@ namespace ReactiveETL
             return op;
         }
 
+        public static GroupByOperation GroupBy(this IObservableOperation observed, string[] columns, Action<Row, Row> aggregate = null)
+        {
+            var op = new GroupByOperation(columns, aggregate);
+            observed.Subscribe(op);
+            return op;
+        }
+
         /// <summary>
         /// Dispatch the grouped elements (trigger for every grouped rows)
         /// </summary>


### PR DESCRIPTION
The new signature allows to implement data aggregation with GroupBy.

Example of use case :
```
private void Run()
{
	var result =
		Input.From(Source)
		.GroupBy(new[] { "Bills" }, Aggregate)
		.WriteFile<Bill>("out.csv")
		.Execute();
}

private void Aggregate(Row aggregatedRow, Row currentRow)
{
	aggregatedRow["Amount"] = aggregatedRow["Amount"] == null ? (long)currentRow["Amount"] : (long)aggregatedRow["Amount"] + (long)currentRow["Amount"];
	aggregatedRow["Count"] = aggregatedRow["Count"] == null ? 1 : (int)aggregatedRow["Count"] + 1;
}
```